### PR TITLE
Originally the repo was breaking immediatly. I fixed that but had to remove using the development network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 anyhow = { version = "1.0", default-features = false }
 iota-streams = { git = "https://github.com/iotaledger/streams", branch  = "develop"}
 iota-conversion = { git = "https://github.com/iotaledger/iota.rs", rev = "03cf531" }
-iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "0ad8e7f" }
+iota-core = { git = "https://github.com/iotaledger/iota.rs", branch = "dev"}

--- a/src/bin/subscriber.rs
+++ b/src/bin/subscriber.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(debug_assertions, allow(dead_code, unused_imports))]
 
-use iota::client as iota_client;
-
 use iota_streams::app_channels::api::tangle::{
     Address, Transport, Subscriber
 };
@@ -89,13 +87,13 @@ fn subscribe<T: Transport>(subscriber: &mut Subscriber<T>, channel_address: &Str
     // Change the default settings to use a lower minimum weight magnitude for the Devnet
     let mut send_opt = SendTrytesOptions::default();
     // default is 14
-    send_opt.min_weight_magnitude = 9;
+    send_opt.min_weight_magnitude = 14;
     send_opt.local_pow = false;
 
-    let url = "https://nodes.devnet.iota.org:443";
+    let node = "https://nodes.thetangle.org:443";
 
     // Connect to an IOTA node
-    let client: Client = Client::new(send_opt, iota_client::ClientBuilder::new().node(url).unwrap().build().unwrap());
+    let client = Client::new_from_url(node);
 
     // Create a new subscriber
     // REPLACE THE SECRET WITH YOUR OWN

--- a/src/bin/subscriber.rs
+++ b/src/bin/subscriber.rs
@@ -98,10 +98,9 @@ fn subscribe<T: Transport>(subscriber: &mut Subscriber<T>, channel_address: &Str
     // Create a new subscriber
     // REPLACE THE SECRET WITH YOUR OWN
     let encoding = "utf-8";
-    let mut subscriber = Subscriber::new("MYSUBSCRIBERSECRETSTRING", encoding, PAYLOAD_BYTES, client);
+    let mut subscriber = Subscriber::new("MYSUBSCRIBERSECRETSTRING9USLK", encoding, PAYLOAD_BYTES, client);
 
     let args: Vec<String> = env::args().collect();
-
     let channel_address = &args[1];
     let announce_message_identifier = &args[2];
     let signed_message_identifier = &args[3];

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
     // Create a new channel
     // REPLACE THE SECRET WITH YOUR OWN
     let multi_branching_flag = false;
-    let mut author = Author::new("MYAUTHORSEC9ETSTRINGAPWOQ9", encoding, PAYLOAD_BYTES, multi_branching_flag, client);
+    let mut author = Author::new("MYAUTHORSECRET99STENRTNE", encoding, PAYLOAD_BYTES, multi_branching_flag, client);
 
     let channel_address = author.channel_address().unwrap().to_string();
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,6 @@ use iota_streams::app::{
     }
 };
 
-use iota::client as iota_client;
-
 use iota_conversion::trytes_converter::{
     bytes_to_trytes
 };
@@ -30,13 +28,13 @@ fn main() {
     // Change the default settings to use a lower minimum weight magnitude for the Devnet
     let mut send_opt = SendTrytesOptions::default();
     // default is 14
-    send_opt.min_weight_magnitude = 9;
+    send_opt.min_weight_magnitude = 14;
     send_opt.local_pow = false;
 
-    let url = "https://nodes.devnet.iota.org:443";
+    let node = "https://nodes.thetangle.org:443";
 
     // Connect to an IOTA node
-    let client: Client = Client::new(send_opt, iota_client::ClientBuilder::new().node(url).unwrap().build().unwrap());
+    let client = Client::new_from_url(node);
 
     let encoding = "utf-8";
 


### PR DESCRIPTION
Pretty much, had to update in the `Cargo.toml`, setting the `iota-core` to the branch `dev`; otherwise it was throwing errors.  I tried really hard getting `ClientBuilder` to work. Ultimately, `ClientBuilder` returns type `iota::Client`. When you instantiate a client from the IOTA streams for some reason it wants wants a `iota_client::client::Client` and throws a fit when it gets a `iota::Client`. I put the full error below. 

I gave up after a few hours. Then just replaced the whole `ClientBuilder` which was trying to setup the MWM to 9, to a normal `iota_streams::app::transport::tangle::client::Client` type using the main net, setting the node to `nodes.thetangle.org`.

This works fine, I was able to build and run your example. 

Here is the full error:
```
error[E0308]: mismatched types
  --> src/main.rs:39:48
   |
39 |     let client: Client = Client::new(send_opt, iota_client::ClientBuilder::new().node(url).unwrap().build().unwrap());
   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `iota_client::client::Client`, found struct `iota::Client`
   |
   = note: perhaps two different versions of crate `iota_client` are being used?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `author`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error[E0308]: mismatched types
  --> src/bin/subscriber.rs:98:48
   |
98 |     let client: Client = Client::new(send_opt, iota_client::ClientBuilder::new().node(url).unwrap().build().unwrap());
   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `iota_client::client::Client`, found struct `iota::Client`
   |
   = note: perhaps two different versions of crate `iota_client` are being used?

```